### PR TITLE
[#151]Fix: 자랑 리스트에 게시물 클릭시 undefined 에러 수정

### DIFF
--- a/src/main/resources/static/js/show_list.js
+++ b/src/main/resources/static/js/show_list.js
@@ -326,11 +326,6 @@ function handleKeyDown(event) {
 document.querySelector(".show-ipt").addEventListener('keydown', handleKeyDown);
 document.querySelector(".search-remove").addEventListener('click', clearSearch);
 
-// 페이지 로드 시 모든 프로젝트 로드
-$(document).ready(function () {
-    searchProjects();
-});
-
 // 사용자 프로젝트 리스트 가져오기
 function myProjectList(memberId) {
     if (memberId == 0)


### PR DESCRIPTION
1. 모든 게시물 가져오는 코드 삭제
2. 삭제 후 관련 기능이었던 검색기능이 가능한지 확인 -> 가능

resolved: #151